### PR TITLE
Add centralized color palettes

### DIFF
--- a/project/app/(tabs)/_layout.tsx
+++ b/project/app/(tabs)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Tabs } from 'expo-router';
 import { ShoppingCart, Calendar, Settings, Plus } from 'lucide-react-native';
 import { StyleSheet, View } from 'react-native';
+import { colors } from '@/constants/Colors';
 
 export default function TabLayout() {
   return (
@@ -8,8 +9,8 @@ export default function TabLayout() {
       screenOptions={{
         headerShown: false,
         tabBarStyle: styles.tabBar,
-        tabBarActiveTintColor: '#007AFF',
-        tabBarInactiveTintColor: '#8E8E93',
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.muted,
         tabBarLabelStyle: styles.tabBarLabel,
       }}>
       <Tabs.Screen
@@ -26,8 +27,8 @@ export default function TabLayout() {
         options={{
           title: 'Criar',
           tabBarIcon: ({ size, color }) => (
-            <View style={[styles.createButton, { backgroundColor: color === '#007AFF' ? '#007AFF' : '#F2F2F7' }]}>
-              <Plus size={size - 4} color={color === '#007AFF' ? 'white' : color} />
+            <View style={[styles.createButton, { backgroundColor: color === colors.primary ? colors.primary : colors.control }]}> 
+              <Plus size={size - 4} color={color === colors.primary ? 'white' : color} />
             </View>
           ),
         }}
@@ -56,9 +57,9 @@ export default function TabLayout() {
 
 const styles = StyleSheet.create({
   tabBar: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderTopWidth: 1,
-    borderTopColor: '#E5E5EA',
+    borderTopColor: colors.border,
     paddingTop: 8,
     paddingBottom: 8,
     height: 84,

--- a/project/app/(tabs)/calendar.tsx
+++ b/project/app/(tabs)/calendar.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ChevronLeft, ChevronRight, Plus } from 'lucide-react-native';
+import { colors } from '@/constants/Colors';
 import { ShoppingList } from '@/types';
 import { StorageService } from '@/services/storage';
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, addMonths, subMonths } from 'date-fns';
@@ -137,7 +138,7 @@ export default function CalendarScreen() {
             style={styles.navButton}
             onPress={() => navigateMonth('prev')}
           >
-            <ChevronLeft size={24} color="#007AFF" />
+            <ChevronLeft size={24} color={colors.primary} />
           </TouchableOpacity>
           
           <Text style={styles.monthTitle}>
@@ -148,7 +149,7 @@ export default function CalendarScreen() {
             style={styles.navButton}
             onPress={() => navigateMonth('next')}
           >
-            <ChevronRight size={24} color="#007AFF" />
+            <ChevronRight size={24} color={colors.primary} />
           </TouchableOpacity>
         </View>
 
@@ -175,7 +176,7 @@ export default function CalendarScreen() {
               style={styles.addButton}
               onPress={() => router.push('/create')}
             >
-              <Plus size={20} color="#007AFF" />
+              <Plus size={20} color={colors.primary} />
             </TouchableOpacity>
           </View>
 
@@ -207,19 +208,19 @@ export default function CalendarScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
   },
   header: {
     paddingHorizontal: 16,
     paddingVertical: 16,
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#E5E5EA',
+    borderBottomColor: colors.border,
   },
   headerTitle: {
     fontSize: 28,
     fontFamily: 'Inter-Bold',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   content: {
     flex: 1,
@@ -230,7 +231,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: 16,
     paddingVertical: 20,
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     marginTop: 16,
     marginHorizontal: 16,
     borderRadius: 12,
@@ -239,14 +240,14 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
     justifyContent: 'center',
     alignItems: 'center',
   },
   monthTitle: {
     fontSize: 20,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     textTransform: 'capitalize',
   },
   calendar: {
@@ -264,7 +265,7 @@ const styles = StyleSheet.create({
   weekDayText: {
     fontSize: 14,
     fontFamily: 'Inter-Medium',
-    color: '#8E8E93',
+    color: colors.muted,
     textAlign: 'center',
     width: 40,
   },
@@ -283,23 +284,23 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   calendarDaySelected: {
-    backgroundColor: '#007AFF',
+    backgroundColor: colors.primary,
   },
   calendarDayToday: {
     borderWidth: 2,
-    borderColor: '#007AFF',
+    borderColor: colors.primary,
   },
   calendarDayText: {
     fontSize: 16,
     fontFamily: 'Inter-Regular',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   calendarDayTextSelected: {
     color: 'white',
     fontFamily: 'Inter-SemiBold',
   },
   calendarDayTextToday: {
-    color: '#007AFF',
+    color: colors.primary,
     fontFamily: 'Inter-SemiBold',
   },
   calendarDayIndicator: {
@@ -309,7 +310,7 @@ const styles = StyleSheet.create({
     width: 16,
     height: 16,
     borderRadius: 8,
-    backgroundColor: '#FF3B30',
+    backgroundColor: colors.danger,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -332,14 +333,14 @@ const styles = StyleSheet.create({
   selectedDateTitle: {
     fontSize: 20,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     textTransform: 'capitalize',
   },
   addButton: {
     width: 36,
     height: 36,
     borderRadius: 18,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -365,14 +366,14 @@ const styles = StyleSheet.create({
   listTitle: {
     fontSize: 16,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     flex: 1,
   },
   listCategory: {
     fontSize: 12,
     fontFamily: 'Inter-Medium',
-    color: '#007AFF',
-    backgroundColor: '#E3F2FD',
+    color: colors.primary,
+    backgroundColor: colors.highlight,
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 8,
@@ -386,22 +387,22 @@ const styles = StyleSheet.create({
   itemCount: {
     fontSize: 14,
     fontFamily: 'Inter-Medium',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   totalPrice: {
     fontSize: 14,
     fontFamily: 'Inter-SemiBold',
-    color: '#34C759',
+    color: colors.success,
   },
   progressBar: {
     height: 3,
-    backgroundColor: '#E5E5EA',
+    backgroundColor: colors.border,
     borderRadius: 2,
     overflow: 'hidden',
   },
   progressFill: {
     height: '100%',
-    backgroundColor: '#34C759',
+    backgroundColor: colors.success,
     borderRadius: 2,
   },
   emptyState: {
@@ -411,11 +412,11 @@ const styles = StyleSheet.create({
   emptyText: {
     fontSize: 16,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
     marginBottom: 16,
   },
   createButton: {
-    backgroundColor: '#007AFF',
+    backgroundColor: colors.primary,
     paddingHorizontal: 20,
     paddingVertical: 10,
     borderRadius: 20,

--- a/project/app/(tabs)/create.tsx
+++ b/project/app/(tabs)/create.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Calendar, Save, Trash2 } from 'lucide-react-native';
+import { colors } from '@/constants/Colors';
 import { ShoppingList, ShoppingItem, ListCategory, UserSubscription } from '@/types';
 import { StorageService } from '@/services/storage';
 import { ParserService } from '@/services/parser';
@@ -168,7 +169,7 @@ export default function CreateScreen() {
           onPress={saveList}
           disabled={items.length === 0}
         >
-          <Save size={20} color={items.length === 0 ? '#C7C7CC' : 'white'} />
+          <Save size={20} color={items.length === 0 ? colors.separator : 'white'} />
           <Text style={[styles.saveButtonText, items.length === 0 && styles.saveButtonTextDisabled]}>
             Salvar
           </Text>
@@ -189,7 +190,7 @@ export default function CreateScreen() {
             value={title}
             onChangeText={setTitle}
             placeholder="Ex: Compras do Mercado"
-            placeholderTextColor="#C7C7CC"
+            placeholderTextColor={colors.separator}
           />
         </View>
 
@@ -221,7 +222,7 @@ export default function CreateScreen() {
         <View style={styles.formSection}>
           <Text style={styles.sectionTitle}>Data</Text>
           <TouchableOpacity style={styles.dateButton}>
-            <Calendar size={20} color="#007AFF" />
+            <Calendar size={20} color={colors.primary} />
             <Text style={styles.dateButtonText}>
               {selectedDate.toLocaleDateString('pt-BR')}
             </Text>
@@ -295,7 +296,7 @@ export default function CreateScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
   },
   header: {
     flexDirection: 'row',
@@ -303,19 +304,19 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: 16,
     paddingVertical: 16,
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#E5E5EA',
+    borderBottomColor: colors.border,
   },
   headerTitle: {
     fontSize: 28,
     fontFamily: 'Inter-Bold',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   saveButton: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '#007AFF',
+    backgroundColor: colors.primary,
     paddingHorizontal: 16,
     paddingVertical: 8,
     borderRadius: 20,
@@ -326,7 +327,7 @@ const styles = StyleSheet.create({
     color: 'white',
   },
   saveButtonTextDisabled: {
-    color: '#C7C7CC',
+    color: colors.separator,
   },
   content: {
     flex: 1,
@@ -337,15 +338,15 @@ const styles = StyleSheet.create({
     padding: 12,
     borderRadius: 8,
     borderLeftWidth: 4,
-    borderLeftColor: '#FF3B30',
+    borderLeftColor: colors.danger,
   },
   errorText: {
     fontSize: 14,
     fontFamily: 'Inter-Medium',
-    color: '#FF3B30',
+    color: colors.danger,
   },
   formSection: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     marginHorizontal: 16,
     marginTop: 16,
     padding: 16,
@@ -354,15 +355,15 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 18,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     marginBottom: 12,
   },
   titleInput: {
     fontSize: 16,
     fontFamily: 'Inter-Regular',
-    color: '#1C1C1E',
+    color: colors.text,
     borderWidth: 1,
-    borderColor: '#E5E5EA',
+    borderColor: colors.border,
     borderRadius: 8,
     padding: 12,
     backgroundColor: '#F9F9F9',
@@ -376,17 +377,17 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderRadius: 20,
     borderWidth: 1,
-    borderColor: '#E5E5EA',
+    borderColor: colors.border,
     backgroundColor: '#F9F9F9',
   },
   categoryButtonSelected: {
-    backgroundColor: '#007AFF',
-    borderColor: '#007AFF',
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
   },
   categoryButtonText: {
     fontSize: 14,
     fontFamily: 'Inter-Medium',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   categoryButtonTextSelected: {
     color: 'white',
@@ -396,17 +397,17 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: 12,
     borderWidth: 1,
-    borderColor: '#E5E5EA',
+    borderColor: colors.border,
     borderRadius: 8,
     backgroundColor: '#F9F9F9',
   },
   dateButtonText: {
     fontSize: 16,
     fontFamily: 'Inter-Regular',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   voiceSection: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     marginHorizontal: 16,
     marginTop: 16,
     padding: 16,
@@ -423,13 +424,13 @@ const styles = StyleSheet.create({
   usageCounter: {
     fontSize: 14,
     fontFamily: 'Inter-Medium',
-    color: '#8E8E93',
+    color: colors.muted,
   },
   upgradeButton: {
     marginTop: 12,
     paddingHorizontal: 16,
     paddingVertical: 8,
-    backgroundColor: '#FF9500',
+    backgroundColor: colors.warning,
     borderRadius: 16,
   },
   upgradeButtonText: {
@@ -451,17 +452,17 @@ const styles = StyleSheet.create({
   totalPrice: {
     fontSize: 18,
     fontFamily: 'Inter-Bold',
-    color: '#34C759',
+    color: colors.success,
   },
   saveButtonBottom: {
     marginTop: 24,
     marginHorizontal: 32,
-    backgroundColor: '#007AFF',
+    backgroundColor: colors.primary,
     borderRadius: 20,
     paddingVertical: 14,
     alignItems: 'center',
     justifyContent: 'center',
-    shadowColor: '#007AFF',
+    shadowColor: colors.primary,
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.2,
     shadowRadius: 4,

--- a/project/app/(tabs)/index.tsx
+++ b/project/app/(tabs)/index.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Plus, Search, Filter } from 'lucide-react-native';
+import { colors } from '@/constants/Colors';
 import { ShoppingList } from '@/types';
 import { StorageService } from '@/services/storage';
 import { format } from 'date-fns';
@@ -128,10 +129,10 @@ export default function ListsScreen() {
         <Text style={styles.headerTitle}>Minhas Listas</Text>
         <View style={styles.headerActions}>
           <TouchableOpacity style={styles.headerButton}>
-            <Search size={24} color="#007AFF" />
+            <Search size={24} color={colors.primary} />
           </TouchableOpacity>
           <TouchableOpacity style={styles.headerButton}>
-            <Filter size={24} color="#007AFF" />
+            <Filter size={24} color={colors.primary} />
           </TouchableOpacity>
         </View>
       </View>
@@ -154,7 +155,7 @@ export default function ListsScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
   },
   header: {
     flexDirection: 'row',
@@ -162,14 +163,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: 16,
     paddingVertical: 16,
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#E5E5EA',
+    borderBottomColor: colors.border,
   },
   headerTitle: {
     fontSize: 28,
     fontFamily: 'Inter-Bold',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   headerActions: {
     flexDirection: 'row',
@@ -178,7 +179,7 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -192,7 +193,7 @@ const styles = StyleSheet.create({
     padding: 32,
   },
   listItem: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderRadius: 16,
     padding: 16,
     marginBottom: 12,
@@ -211,14 +212,14 @@ const styles = StyleSheet.create({
   listTitle: {
     fontSize: 18,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     flex: 1,
   },
   listCategory: {
     fontSize: 12,
     fontFamily: 'Inter-Medium',
-    color: '#007AFF',
-    backgroundColor: '#E3F2FD',
+    color: colors.primary,
+    backgroundColor: colors.highlight,
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 8,
@@ -226,7 +227,7 @@ const styles = StyleSheet.create({
   listDate: {
     fontSize: 14,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
     marginBottom: 12,
   },
   listStats: {
@@ -238,22 +239,22 @@ const styles = StyleSheet.create({
   itemCount: {
     fontSize: 14,
     fontFamily: 'Inter-Medium',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   totalPrice: {
     fontSize: 16,
     fontFamily: 'Inter-SemiBold',
-    color: '#34C759',
+    color: colors.success,
   },
   progressBar: {
     height: 4,
-    backgroundColor: '#E5E5EA',
+    backgroundColor: colors.border,
     borderRadius: 2,
     overflow: 'hidden',
   },
   progressFill: {
     height: '100%',
-    backgroundColor: '#34C759',
+    backgroundColor: colors.success,
     borderRadius: 2,
   },
   emptyState: {
@@ -262,13 +263,13 @@ const styles = StyleSheet.create({
   emptyTitle: {
     fontSize: 24,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     marginBottom: 8,
   },
   emptySubtitle: {
     fontSize: 16,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
     textAlign: 'center',
     marginBottom: 32,
     lineHeight: 24,
@@ -276,7 +277,7 @@ const styles = StyleSheet.create({
   createButton: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '#007AFF',
+    backgroundColor: colors.primary,
     paddingHorizontal: 24,
     paddingVertical: 12,
     borderRadius: 24,

--- a/project/app/(tabs)/list/[id].tsx
+++ b/project/app/(tabs)/list/[id].tsx
@@ -5,6 +5,7 @@ import { ShoppingList, ShoppingItem } from '@/types';
 import { StorageService } from '@/services/storage';
 import { ParserService } from '@/services/parser';
 import ItemTile from '@/components/ItemTile';
+import { colors } from '@/constants/Colors';
 
 export default function ListDetailScreen() {
   const params = useLocalSearchParams();
@@ -117,7 +118,7 @@ export default function ListDetailScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
     padding: 16,
   },
   centered: {
@@ -126,23 +127,23 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   errorText: {
-    color: '#FF3B30',
+    color: colors.danger,
     fontSize: 16,
   },
   title: {
     fontSize: 24,
     fontFamily: 'Inter-Bold',
-    color: '#1C1C1E',
+    color: colors.text,
     marginBottom: 4,
   },
   category: {
     fontSize: 16,
-    color: '#007AFF',
+    color: colors.primary,
     marginBottom: 4,
   },
   date: {
     fontSize: 14,
-    color: '#8E8E93',
+    color: colors.muted,
     marginBottom: 16,
   },
   itemsSection: {
@@ -150,7 +151,7 @@ const styles = StyleSheet.create({
   },
   itemRow: {
     marginBottom: 16,
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderRadius: 12,
     padding: 8,
     shadowColor: '#000',
@@ -167,40 +168,40 @@ const styles = StyleSheet.create({
   },
   priceLabel: {
     fontSize: 14,
-    color: '#8E8E93',
+    color: colors.muted,
     marginRight: 8,
   },
   priceInput: {
     width: 80,
     height: 32,
     borderWidth: 1,
-    borderColor: '#C7C7CC',
+    borderColor: colors.separator,
     borderRadius: 6,
     textAlign: 'center',
     fontSize: 16,
-    backgroundColor: 'white',
-    color: '#1C1C1E',
+    backgroundColor: colors.surface,
+    color: colors.text,
   },
   totalLabel: {
     fontSize: 18,
-    color: '#1C1C1E',
+    color: colors.text,
     marginTop: 16,
     marginBottom: 4,
     fontFamily: 'Inter-SemiBold',
   },
   totalValue: {
     fontSize: 22,
-    color: '#34C759',
+    color: colors.success,
     fontFamily: 'Inter-Bold',
     marginBottom: 24,
   },
   saveButton: {
-    backgroundColor: '#007AFF',
+    backgroundColor: colors.primary,
     borderRadius: 20,
     paddingVertical: 14,
     alignItems: 'center',
     justifyContent: 'center',
-    shadowColor: '#007AFF',
+    shadowColor: colors.primary,
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.2,
     shadowRadius: 4,

--- a/project/app/(tabs)/settings.tsx
+++ b/project/app/(tabs)/settings.tsx
@@ -23,6 +23,7 @@ import {
 import { UserSubscription } from '@/types';
 import { StorageService } from '@/services/storage';
 import { router } from 'expo-router';
+import { colors } from '@/constants/Colors';
 
 export default function SettingsScreen() {
   const [subscription, setSubscription] = useState<UserSubscription | null>(null);
@@ -89,11 +90,11 @@ export default function SettingsScreen() {
         onPress={() => router.push('/paywall')}
       >
         <View style={styles.cardHeader}>
-          <Crown size={24} color={subscription.isPremium ? '#FFD700' : '#8E8E93'} />
+          <Crown size={24} color={subscription.isPremium ? '#FFD700' : colors.muted} />
           <Text style={[styles.cardTitle, subscription.isPremium && styles.premiumText]}>
             {subscription.isPremium ? 'ListaVox Premium' : 'ListaVox Gratuito'}
           </Text>
-          <ChevronRight size={20} color="#8E8E93" />
+          <ChevronRight size={20} color={colors.muted} />
         </View>
         
         <View style={styles.subscriptionStats}>
@@ -145,7 +146,7 @@ export default function SettingsScreen() {
         </View>
       </View>
       
-      {rightElement || (onPress && <ChevronRight size={20} color="#8E8E93" />)}
+      {rightElement || (onPress && <ChevronRight size={20} color={colors.muted} />)}
     </TouchableOpacity>
   );
 
@@ -162,34 +163,34 @@ export default function SettingsScreen() {
           <Text style={styles.sectionTitle}>Funcionalidades</Text>
           
           {renderSettingItem(
-            <Mic size={20} color="#007AFF" />,
+            <Mic size={20} color={colors.primary} />,
             'Reconhecimento de Voz',
             'Configurar idioma e sensibilidade',
             () => {},
             <Switch
               value={voiceConfirmation}
               onValueChange={setVoiceConfirmation}
-              trackColor={{ false: '#E5E5EA', true: '#007AFF' }}
+              trackColor={{ false: colors.border, true: colors.primary }}
               thumbColor="white"
             />
           )}
           
           {renderSettingItem(
-            <Camera size={20} color="#007AFF" />,
+            <Camera size={20} color={colors.primary} />,
             'Scanner de Preços',
             subscription?.isPremium ? 'Disponível' : 'Apenas Premium',
             () => {}
           )}
           
           {renderSettingItem(
-            <Bell size={20} color="#007AFF" />,
+            <Bell size={20} color={colors.primary} />,
             'Notificações',
             'Lembretes de compras',
             () => {},
             <Switch
               value={notifications}
               onValueChange={setNotifications}
-              trackColor={{ false: '#E5E5EA', true: '#007AFF' }}
+              trackColor={{ false: colors.border, true: colors.primary }}
               thumbColor="white"
             />
           )}
@@ -199,21 +200,21 @@ export default function SettingsScreen() {
           <Text style={styles.sectionTitle}>Suporte</Text>
           
           {renderSettingItem(
-            <HelpCircle size={20} color="#007AFF" />,
+            <HelpCircle size={20} color={colors.primary} />,
             'Central de Ajuda',
             'Tutoriais e perguntas frequentes',
             () => {}
           )}
           
           {renderSettingItem(
-            <Star size={20} color="#007AFF" />,
+            <Star size={20} color={colors.primary} />,
             'Avaliar App',
             'Deixe sua avaliação na loja',
             () => {}
           )}
           
           {renderSettingItem(
-            <Shield size={20} color="#007AFF" />,
+            <Shield size={20} color={colors.primary} />,
             'Privacidade',
             'Política de privacidade e termos',
             () => {}
@@ -224,7 +225,7 @@ export default function SettingsScreen() {
           <Text style={styles.sectionTitle}>Dados</Text>
           
           {renderSettingItem(
-            <Trash2 size={20} color="#FF3B30" />,
+            <Trash2 size={20} color={colors.danger} />,
             'Limpar Todos os Dados',
             'Remove todas as listas e configurações',
             clearAllData
@@ -247,25 +248,25 @@ export default function SettingsScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
   },
   header: {
     paddingHorizontal: 16,
     paddingVertical: 16,
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderBottomWidth: 1,
-    borderBottomColor: '#E5E5EA',
+    borderBottomColor: colors.border,
   },
   headerTitle: {
     fontSize: 28,
     fontFamily: 'Inter-Bold',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   content: {
     flex: 1,
   },
   card: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     marginHorizontal: 16,
     marginTop: 16,
     borderRadius: 16,
@@ -289,7 +290,7 @@ const styles = StyleSheet.create({
   cardTitle: {
     fontSize: 18,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     flex: 1,
     marginLeft: 12,
   },
@@ -307,18 +308,18 @@ const styles = StyleSheet.create({
   statValue: {
     fontSize: 24,
     fontFamily: 'Inter-Bold',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   statLabel: {
     fontSize: 12,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
     marginTop: 4,
   },
   upgradeText: {
     fontSize: 14,
     fontFamily: 'Inter-Medium',
-    color: '#007AFF',
+    color: colors.primary,
     textAlign: 'center',
   },
   section: {
@@ -327,7 +328,7 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 16,
     fontFamily: 'Inter-SemiBold',
-    color: '#8E8E93',
+    color: colors.muted,
     marginLeft: 16,
     marginBottom: 8,
     textTransform: 'uppercase',
@@ -336,11 +337,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     paddingHorizontal: 16,
     paddingVertical: 16,
     borderBottomWidth: 1,
-    borderBottomColor: '#F2F2F7',
+    borderBottomColor: colors.control,
   },
   settingLeft: {
     flexDirection: 'row',
@@ -351,7 +352,7 @@ const styles = StyleSheet.create({
     width: 32,
     height: 32,
     borderRadius: 8,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 12,
@@ -362,12 +363,12 @@ const styles = StyleSheet.create({
   settingTitle: {
     fontSize: 16,
     fontFamily: 'Inter-Regular',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   settingSubtitle: {
     fontSize: 14,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
     marginTop: 2,
   },
   footer: {
@@ -377,12 +378,12 @@ const styles = StyleSheet.create({
   footerText: {
     fontSize: 14,
     fontFamily: 'Inter-Medium',
-    color: '#8E8E93',
+    color: colors.muted,
   },
   footerSubtext: {
     fontSize: 12,
     fontFamily: 'Inter-Regular',
-    color: '#C7C7CC',
+    color: colors.separator,
     marginTop: 4,
   },
 });

--- a/project/app/camera.tsx
+++ b/project/app/camera.tsx
@@ -9,6 +9,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { CameraView, CameraType, useCameraPermissions } from 'expo-camera';
 import { X, Camera, FlipHorizontal, Zap } from 'lucide-react-native';
+import { colors } from '@/constants/Colors';
 import { router, useLocalSearchParams } from 'expo-router';
 
 export default function CameraScreen() {
@@ -26,7 +27,7 @@ export default function CameraScreen() {
     return (
       <SafeAreaView style={styles.container}>
         <View style={styles.permissionContainer}>
-          <Camera size={64} color="#8E8E93" />
+          <Camera size={64} color={colors.muted} />
           <Text style={styles.permissionTitle}>
             Acesso à Câmera Necessário
           </Text>
@@ -196,12 +197,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: 32,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
   },
   permissionTitle: {
     fontSize: 24,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     marginTop: 24,
     marginBottom: 16,
     textAlign: 'center',
@@ -209,13 +210,13 @@ const styles = StyleSheet.create({
   permissionText: {
     fontSize: 16,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
     textAlign: 'center',
     lineHeight: 24,
     marginBottom: 32,
   },
   permissionButton: {
-    backgroundColor: '#007AFF',
+    backgroundColor: colors.primary,
     paddingHorizontal: 32,
     paddingVertical: 16,
     borderRadius: 24,
@@ -272,7 +273,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     width: 30,
     height: 30,
-    borderColor: '#007AFF',
+    borderColor: colors.primary,
     borderWidth: 3,
     borderTopWidth: 3,
     borderLeftWidth: 3,
@@ -336,17 +337,17 @@ const styles = StyleSheet.create({
     width: 80,
     height: 80,
     borderRadius: 40,
-    backgroundColor: '#007AFF',
+    backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
-    shadowColor: '#007AFF',
+    shadowColor: colors.primary,
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
     elevation: 8,
   },
   captureButtonDisabled: {
-    backgroundColor: '#8E8E93',
+    backgroundColor: colors.muted,
     shadowOpacity: 0,
     elevation: 0,
   },

--- a/project/components/ItemTile.tsx
+++ b/project/components/ItemTile.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, TextInput } from 'react-native';
+import { colors } from '@/constants/Colors';
 import { Check, Camera, Trash2 } from 'lucide-react-native';
 import Animated, { 
   useSharedValue, 
@@ -113,7 +114,7 @@ export default function ItemTile({
             onPress={() => onScan(item.id)}
             activeOpacity={0.7}
           >
-            <Camera size={20} color="#007AFF" />
+            <Camera size={20} color={colors.primary} />
           </TouchableOpacity>
           
           <TouchableOpacity
@@ -121,7 +122,7 @@ export default function ItemTile({
             onPress={() => onDelete(item.id)}
             activeOpacity={0.7}
           >
-            <Trash2 size={20} color="#FF3B30" />
+            <Trash2 size={20} color={colors.danger} />
           </TouchableOpacity>
         </View>
       )}
@@ -133,7 +134,7 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     marginHorizontal: 16,
     marginVertical: 4,
     borderRadius: 12,
@@ -154,14 +155,14 @@ const styles = StyleSheet.create({
     height: 24,
     borderRadius: 12,
     borderWidth: 2,
-    borderColor: '#C7C7CC',
+    borderColor: colors.separator,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 12,
   },
   checkboxChecked: {
-    backgroundColor: '#34C759',
-    borderColor: '#34C759',
+    backgroundColor: colors.success,
+    borderColor: colors.success,
   },
   itemInfo: {
     flex: 1,
@@ -169,12 +170,12 @@ const styles = StyleSheet.create({
   itemName: {
     fontSize: 16,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     marginBottom: 4,
   },
   itemNameChecked: {
     textDecorationLine: 'line-through',
-    color: '#8E8E93',
+    color: colors.muted,
   },
   itemDetails: {
     flexDirection: 'row',
@@ -183,8 +184,8 @@ const styles = StyleSheet.create({
   itemCategory: {
     fontSize: 12,
     fontFamily: 'Inter-Medium',
-    color: '#007AFF',
-    backgroundColor: '#E3F2FD',
+    color: colors.primary,
+    backgroundColor: colors.highlight,
     paddingHorizontal: 6,
     paddingVertical: 2,
     borderRadius: 4,
@@ -192,10 +193,10 @@ const styles = StyleSheet.create({
   itemPrice: {
     fontSize: 14,
     fontFamily: 'Inter-SemiBold',
-    color: '#34C759',
+    color: colors.success,
   },
   scannedPrice: {
-    color: '#FF9500',
+    color: colors.warning,
   },
   actions: {
     flexDirection: 'row',
@@ -205,7 +206,7 @@ const styles = StyleSheet.create({
     width: 36,
     height: 36,
     borderRadius: 18,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -219,31 +220,31 @@ const styles = StyleSheet.create({
     width: 28,
     height: 28,
     borderRadius: 14,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
     justifyContent: 'center',
     alignItems: 'center',
     marginHorizontal: 2,
   },
   qtyButtonText: {
     fontSize: 18,
-    color: '#007AFF',
+    color: colors.primary,
     fontWeight: 'bold',
   },
   qtyInput: {
     width: 48,
     height: 28,
     borderWidth: 1,
-    borderColor: '#C7C7CC',
+    borderColor: colors.separator,
     borderRadius: 6,
     textAlign: 'center',
     fontSize: 16,
     marginHorizontal: 2,
-    backgroundColor: 'white',
-    color: '#1C1C1E',
+    backgroundColor: colors.surface,
+    color: colors.text,
   },
   qtyUnit: {
     fontSize: 14,
-    color: '#8E8E93',
+    color: colors.muted,
     marginLeft: 4,
   },
 });

--- a/project/constants/Colors.ts
+++ b/project/constants/Colors.ts
@@ -1,0 +1,126 @@
+export const palettes = {
+  fresh: {
+    light: {
+      primary: '#007AFF',
+      success: '#34C759',
+      danger: '#FF3B30',
+      warning: '#FF9500',
+      background: '#F2F2F7',
+      surface: '#FFFFFF',
+      text: '#1C1C1E',
+      muted: '#8E8E93',
+      border: '#E5E5EA',
+      control: '#F2F2F7',
+      highlight: '#E3F2FD',
+      separator: '#C7C7CC'
+    },
+    dark: {
+      primary: '#0A84FF',
+      success: '#30D158',
+      danger: '#FF453A',
+      warning: '#FF9F0A',
+      background: '#1C1C1E',
+      surface: '#2C2C2E',
+      text: '#FFFFFF',
+      muted: '#8E8E93',
+      border: '#3A3A3C',
+      control: '#48484A',
+      highlight: '#0A84FF20',
+      separator: '#636366'
+    }
+  },
+  tropical: {
+    light: {
+      primary: '#00B894',
+      success: '#26de81',
+      danger: '#ff6b6b',
+      warning: '#fdcb6e',
+      background: '#E0F2F1',
+      surface: '#FFFFFF',
+      text: '#004D40',
+      muted: '#4F4F4F',
+      border: '#B2DFDB',
+      control: '#C8E6C9',
+      highlight: '#B2EBF2',
+      separator: '#A7A7A7'
+    },
+    dark: {
+      primary: '#1dd1a1',
+      success: '#10ac84',
+      danger: '#ee5253',
+      warning: '#feca57',
+      background: '#004D40',
+      surface: '#005B4F',
+      text: '#FFFFFF',
+      muted: '#B0BEC5',
+      border: '#004D40',
+      control: '#00695C',
+      highlight: '#004D40',
+      separator: '#607D8B'
+    }
+  },
+  berry: {
+    light: {
+      primary: '#AF52DE',
+      success: '#34C759',
+      danger: '#FF375F',
+      warning: '#FF9500',
+      background: '#F8EAF9',
+      surface: '#FFFFFF',
+      text: '#1D1331',
+      muted: '#6E6E73',
+      border: '#E5E5EA',
+      control: '#F3E5F5',
+      highlight: '#F2E1F9',
+      separator: '#C7C7CC'
+    },
+    dark: {
+      primary: '#BF5AF2',
+      success: '#30D158',
+      danger: '#FF375F',
+      warning: '#FF9F0A',
+      background: '#1D1331',
+      surface: '#2C1A43',
+      text: '#FFFFFF',
+      muted: '#A284B7',
+      border: '#3A3A3C',
+      control: '#3C2E56',
+      highlight: '#2C1A43',
+      separator: '#636366'
+    }
+  },
+  orchard: {
+    light: {
+      primary: '#5AC8FA',
+      success: '#34C759',
+      danger: '#FF3B30',
+      warning: '#FF9500',
+      background: '#EFFBFF',
+      surface: '#FFFFFF',
+      text: '#1C1C1E',
+      muted: '#8E8E93',
+      border: '#E5E5EA',
+      control: '#DFF6FD',
+      highlight: '#E0F7FF',
+      separator: '#C7C7CC'
+    },
+    dark: {
+      primary: '#64D2FF',
+      success: '#32D74B',
+      danger: '#FF453A',
+      warning: '#FF9F0A',
+      background: '#00141E',
+      surface: '#0A1F29',
+      text: '#FFFFFF',
+      muted: '#8E8E93',
+      border: '#3A3A3C',
+      control: '#123645',
+      highlight: '#0A1F29',
+      separator: '#636366'
+    }
+  }
+} as const;
+
+export type PaletteName = keyof typeof palettes;
+
+export const colors = palettes.fresh.light;


### PR DESCRIPTION
## Summary
- centralize color palette in `Colors.ts`
- use palette colors in ItemTile, Camera screen, and tab screens

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608ae9ae5083309eb15777bcf51388