### PR TITLE
Fix framework ready effect dependencies

### DIFF
--- a/project/hooks/useFrameworkReady.ts
+++ b/project/hooks/useFrameworkReady.ts
@@ -9,5 +9,5 @@ declare global {
 export function useFrameworkReady() {
   useEffect(() => {
     window.frameworkReady?.();
-  });
+  }, []);
 }


### PR DESCRIPTION
## Summary
- ensure `useFrameworkReady` hook only runs once by adding empty dependency array

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608aea515c8330afdf52775a23231f