### PR TITLE
Fix list title editing and delete button

### DIFF
--- a/project/app/(tabs)/index.tsx
+++ b/project/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import { View, Text, FlatList, StyleSheet, Pressable } from 'react-native';
-import { Link } from 'expo-router';
+import { router } from 'expo-router';
 import { useTheme } from '@/context/ThemeContext';
 import { useShoppingLists } from '@/services/storage';
 
@@ -14,17 +14,24 @@ export default function HomeScreen() {
         data={lists}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => (
-          <Link href={`/list/${item.id}`} asChild>
-            <Pressable style={[styles.listItem, { backgroundColor: colors.surface }]}>
-              <View>
-                <Text style={[styles.listTitle, { color: colors.text }]}>{item.title}</Text>
-                <Text style={[styles.listDate, { color: colors.text }]}> {item.date.toLocaleDateString()} </Text>
-              </View>
-              <Pressable onPress={() => deleteList(item.id)} style={styles.deleteButton}>
-                <Text style={{ color: '#E53935' }}>Excluir</Text>
-              </Pressable>
+          <Pressable
+            style={[styles.listItem, { backgroundColor: colors.surface }]}
+            onPress={() => router.push(`/list/${item.id}`)}
+          >
+            <View>
+              <Text style={[styles.listTitle, { color: colors.text }]}>{item.title}</Text>
+              <Text style={[styles.listDate, { color: colors.text }]}> {item.date.toLocaleDateString()} </Text>
+            </View>
+            <Pressable
+              onPress={(e) => {
+                e.stopPropagation();
+                deleteList(item.id);
+              }}
+              style={styles.deleteButton}
+            >
+              <Text style={{ color: '#E53935' }}>Excluir</Text>
             </Pressable>
-          </Link>
+          </Pressable>
         )}
         contentContainerStyle={{ gap: 10 }}
       />

--- a/project/app/(tabs)/list/[id].tsx
+++ b/project/app/(tabs)/list/[id].tsx
@@ -57,7 +57,13 @@ export default function ListDetailScreen() {
   const saveEdits = async () => {
     if (!list) return;
     try {
-      const updatedList = { ...list, items, totalPrice: ParserService.calculateTotal(items), updatedAt: new Date() };
+      const updatedList = {
+        ...list,
+        title: title.trim() || list.title,
+        items,
+        totalPrice: ParserService.calculateTotal(items),
+        updatedAt: new Date(),
+      };
       await StorageService.saveList(updatedList);
       setList(updatedList);
       Alert.alert('Lista atualizada!', 'As alterações foram salvas.');
@@ -78,7 +84,11 @@ export default function ListDetailScreen() {
 
   return (
     <ScrollView style={styles.container}>
-      <Text style={styles.title}>{title}</Text>
+      <TextInput
+        style={styles.titleInput}
+        value={title}
+        onChangeText={setTitle}
+      />
       <Text style={styles.category}>{list.category}</Text>
       <Text style={styles.date}>{list.date.toLocaleDateString('pt-BR')}</Text>
       <View style={styles.itemsSection}>
@@ -129,6 +139,17 @@ const styles = StyleSheet.create({
   errorText: {
     color: colors.danger,
     fontSize: 16,
+  },
+  titleInput: {
+    fontSize: 24,
+    fontFamily: 'Inter-Bold',
+    color: colors.text,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 8,
+    padding: 8,
+    marginBottom: 4,
+    backgroundColor: '#F9F9F9',
   },
   title: {
     fontSize: 24,


### PR DESCRIPTION
## Summary
- allow editing shopping list title with TextInput
- persist edited title when saving
- update home screen list delete behavior to prevent navigation

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608fdb45108330b7e265aa10d0f0f0