### PR TITLE
Add missing Babel config

### DIFF
--- a/project/babel.config.js
+++ b/project/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      ['module-resolver', {
+        alias: { '@': './' }
+      }],
+      'react-native-reanimated/plugin'
+    ]
+  };
+};


### PR DESCRIPTION
## Summary
- add babel.config.js with Expo preset and module resolver

## Testing
- `npx tsc --noEmit` *(fails: cannot find expo/tsconfig.base)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860963ab9248330b5f02b9f3f41d0ec