### PR TITLE
Add missing Babel plugin

### DIFF
--- a/project/package.json
+++ b/project/package.json
@@ -53,6 +53,7 @@
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
     "@types/uuid": "^10.0.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "babel-plugin-module-resolver": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `babel-plugin-module-resolver` to devDependencies for Metro bundler

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c657316c83309e1a88c8e0d90c06