### PR TITLE
Add theme palette support

### DIFF
--- a/project/constants/Colors.ts
+++ b/project/constants/Colors.ts
@@ -1,35 +1,126 @@
 export const palettes = {
-  blue: {
-    primary: '#007AFF'
+  fresh: {
+    light: {
+      primary: '#007AFF',
+      success: '#34C759',
+      danger: '#FF3B30',
+      warning: '#FF9500',
+      background: '#F2F2F7',
+      surface: '#FFFFFF',
+      text: '#1C1C1E',
+      muted: '#8E8E93',
+      border: '#E5E5EA',
+      control: '#F2F2F7',
+      highlight: '#E3F2FD',
+      separator: '#C7C7CC'
+    },
+    dark: {
+      primary: '#0A84FF',
+      success: '#30D158',
+      danger: '#FF453A',
+      warning: '#FF9F0A',
+      background: '#1C1C1E',
+      surface: '#2C2C2E',
+      text: '#FFFFFF',
+      muted: '#8E8E93',
+      border: '#3A3A3C',
+      control: '#48484A',
+      highlight: '#0A84FF20',
+      separator: '#636366'
+    }
   },
-  green: {
-    primary: '#34C759'
+  tropical: {
+    light: {
+      primary: '#00B894',
+      success: '#26de81',
+      danger: '#ff6b6b',
+      warning: '#fdcb6e',
+      background: '#E0F2F1',
+      surface: '#FFFFFF',
+      text: '#004D40',
+      muted: '#4F4F4F',
+      border: '#B2DFDB',
+      control: '#C8E6C9',
+      highlight: '#B2EBF2',
+      separator: '#A7A7A7'
+    },
+    dark: {
+      primary: '#1dd1a1',
+      success: '#10ac84',
+      danger: '#ee5253',
+      warning: '#feca57',
+      background: '#004D40',
+      surface: '#005B4F',
+      text: '#FFFFFF',
+      muted: '#B0BEC5',
+      border: '#004D40',
+      control: '#00695C',
+      highlight: '#004D40',
+      separator: '#607D8B'
+    }
   },
-  orange: {
-    primary: '#FF9500'
+  berry: {
+    light: {
+      primary: '#AF52DE',
+      success: '#34C759',
+      danger: '#FF375F',
+      warning: '#FF9500',
+      background: '#F8EAF9',
+      surface: '#FFFFFF',
+      text: '#1D1331',
+      muted: '#6E6E73',
+      border: '#E5E5EA',
+      control: '#F3E5F5',
+      highlight: '#F2E1F9',
+      separator: '#C7C7CC'
+    },
+    dark: {
+      primary: '#BF5AF2',
+      success: '#30D158',
+      danger: '#FF375F',
+      warning: '#FF9F0A',
+      background: '#1D1331',
+      surface: '#2C1A43',
+      text: '#FFFFFF',
+      muted: '#A284B7',
+      border: '#3A3A3C',
+      control: '#3C2E56',
+      highlight: '#2C1A43',
+      separator: '#636366'
+    }
+  },
+  orchard: {
+    light: {
+      primary: '#5AC8FA',
+      success: '#34C759',
+      danger: '#FF3B30',
+      warning: '#FF9500',
+      background: '#EFFBFF',
+      surface: '#FFFFFF',
+      text: '#1C1C1E',
+      muted: '#8E8E93',
+      border: '#E5E5EA',
+      control: '#DFF6FD',
+      highlight: '#E0F7FF',
+      separator: '#C7C7CC'
+    },
+    dark: {
+      primary: '#64D2FF',
+      success: '#32D74B',
+      danger: '#FF453A',
+      warning: '#FF9F0A',
+      background: '#00141E',
+      surface: '#0A1F29',
+      text: '#FFFFFF',
+      muted: '#8E8E93',
+      border: '#3A3A3C',
+      control: '#123645',
+      highlight: '#0A1F29',
+      separator: '#636366'
+    }
   }
 } as const;
 
 export type PaletteName = keyof typeof palettes;
 
-export interface ThemeColors {
-  text: string;
-  background: string;
-  surface: string;
-  primary: string;
-}
-
-export const baseColors = {
-  light: {
-    text: '#1C1C1E',
-    background: '#F2F2F7',
-    surface: '#FFFFFF'
-  },
-  dark: {
-    text: '#FFFFFF',
-    background: '#1C1C1E',
-    surface: '#2C2C2E'
-  }
-} as const;
-
-export type ColorScheme = keyof typeof baseColors;
+export const colors = palettes.fresh.light;

--- a/project/context/ThemeContext.tsx
+++ b/project/context/ThemeContext.tsx
@@ -1,52 +1,75 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useState, useContext, useMemo, ReactNode } from 'react';
 import { useColorScheme } from 'react-native';
+import { palettes, PaletteName } from '../constants/Colors';
+import { setItem, getItem } from '../services/storage';
 
-export type ThemeColors = {
-  primary: string;
-  background: string;
-  surface: string;
-  text: string;
-};
-
-const lightColors: ThemeColors = {
-  primary: '#007AFF',
-  background: '#F2F2F7',
-  surface: '#FFFFFF',
-  text: '#1C1C1E',
-};
-
-const darkColors: ThemeColors = {
-  primary: '#0A84FF',
-  background: '#000000',
-  surface: '#1C1C1E',
-  text: '#FFFFFF',
-};
-
-interface ThemeContextValue {
-  colors: ThemeColors;
-  toggleTheme: () => void;
-  isDark: boolean;
+interface ThemeContextType {
+  colors: typeof palettes.fresh.light;
+  paletteName: PaletteName;
+  colorScheme: 'light' | 'dark';
+  setPalette: (name: PaletteName) => void;
+  toggleColorScheme: () => void;
 }
 
-const ThemeContext = createContext<ThemeContextValue>({
-  colors: lightColors,
-  toggleTheme: () => {},
-  isDark: false,
-});
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => {
   const systemScheme = useColorScheme();
-  const [isDark, setIsDark] = useState(systemScheme === 'dark');
+  const [colorScheme, setColorScheme] = useState<'light' | 'dark'>(systemScheme || 'light');
+  const [paletteName, setPaletteName] = useState<PaletteName>('fresh');
 
-  const toggleTheme = () => setIsDark((prev) => !prev);
+  React.useEffect(() => {
+    const loadTheme = async () => {
+      const savedPalette = await getItem<PaletteName>('theme_palette');
+      const savedScheme = await getItem<'light' | 'dark'>('theme_scheme');
+      if (savedPalette) {
+        setPaletteName(savedPalette);
+      }
+      if (savedScheme) {
+        setColorScheme(savedScheme);
+      } else {
+        setColorScheme(systemScheme || 'light');
+      }
+    };
+    loadTheme();
+  }, [systemScheme]);
 
-  const colors = isDark ? darkColors : lightColors;
+  const setPalette = async (name: PaletteName) => {
+    setPaletteName(name);
+    await setItem('theme_palette', name);
+  };
+
+  const toggleColorScheme = async () => {
+    const newScheme = colorScheme === 'light' ? 'dark' : 'light';
+    setColorScheme(newScheme);
+    await setItem('theme_scheme', newScheme);
+  };
+
+  const colors = palettes[paletteName][colorScheme];
+
+  const contextValue = useMemo(() => ({
+    colors,
+    paletteName,
+    setPalette,
+    colorScheme,
+    toggleColorScheme,
+  }), [colors, paletteName, colorScheme]);
 
   return (
-    <ThemeContext.Provider value={{ colors, toggleTheme, isDark }}>
+    <ThemeContext.Provider value={contextValue}>
       {children}
     </ThemeContext.Provider>
   );
 };
 
-export const useTheme = () => useContext(ThemeContext);
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/project/package.json
+++ b/project/package.json
@@ -53,6 +53,7 @@
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
     "@types/uuid": "^10.0.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "babel-plugin-module-resolver": "^5.0.0"
   }
 }

--- a/project/services/storage.ts
+++ b/project/services/storage.ts
@@ -157,3 +157,23 @@ export function useShoppingLists() {
 
   return { lists, loading, loadLists, deleteList, saveList };
 }
+
+export async function setItem<T>(key: string, value: T): Promise<void> {
+  try {
+    await AsyncStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error('Error setting item:', error);
+    throw error;
+  }
+}
+
+export async function getItem<T>(key: string): Promise<T | null> {
+  try {
+    const data = await AsyncStorage.getItem(key);
+    if (!data) return null;
+    return JSON.parse(data) as T;
+  } catch (error) {
+    console.error('Error getting item:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- restore color palettes with default export
- restore theme context with palette and scheme controls
- reintroduce `setItem`/`getItem` helpers in storage

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c657316c83309e1a88c8e0d90c06