### PR TITLE
Add theme palette support

### DIFF
--- a/project/app/(tabs)/calendar.tsx
+++ b/project/app/(tabs)/calendar.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ChevronLeft, ChevronRight, Plus } from 'lucide-react-native';
-import { colors } from '@/constants/Colors';
+import { useTheme } from '@/context/ThemeContext';
 import { ShoppingList } from '@/types';
 import { StorageService } from '@/services/storage';
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, addMonths, subMonths } from 'date-fns';
@@ -16,6 +16,7 @@ import { ptBR } from 'date-fns/locale';
 import { router } from 'expo-router';
 
 export default function CalendarScreen() {
+  const { colors } = useTheme();
   const [currentDate, setCurrentDate] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [lists, setLists] = useState<ShoppingList[]>([]);
@@ -251,7 +252,7 @@ const styles = StyleSheet.create({
     textTransform: 'capitalize',
   },
   calendar: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     marginHorizontal: 16,
     marginTop: 8,
     borderRadius: 12,
@@ -348,7 +349,7 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   listItem: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderRadius: 12,
     padding: 16,
     shadowColor: '#000',

--- a/project/app/(tabs)/create.tsx
+++ b/project/app/(tabs)/create.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Calendar, Save, Trash2 } from 'lucide-react-native';
-import { colors } from '@/constants/Colors';
+import { useTheme } from '@/context/ThemeContext';
 import { ShoppingList, ShoppingItem, ListCategory, UserSubscription } from '@/types';
 import { StorageService } from '@/services/storage';
 import { ParserService } from '@/services/parser';
@@ -22,6 +22,7 @@ import { router } from 'expo-router';
 const CATEGORIES: ListCategory[] = ['Mercado', 'Farmácia', 'Papelaria', 'Pet Shop'];
 
 export default function CreateScreen() {
+  const { colors } = useTheme();
   const [title, setTitle] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<ListCategory>('Mercado');
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -366,7 +367,7 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
     borderRadius: 8,
     padding: 12,
-    backgroundColor: '#F9F9F9',
+    backgroundColor: colors.control,
   },
   categoryGrid: {
     flexDirection: 'row',
@@ -378,7 +379,7 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     borderWidth: 1,
     borderColor: colors.border,
-    backgroundColor: '#F9F9F9',
+    backgroundColor: colors.control,
   },
   categoryButtonSelected: {
     backgroundColor: colors.primary,
@@ -399,7 +400,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.border,
     borderRadius: 8,
-    backgroundColor: '#F9F9F9',
+    backgroundColor: colors.control,
   },
   dateButtonText: {
     fontSize: 16,

--- a/project/app/(tabs)/list/[id].tsx
+++ b/project/app/(tabs)/list/[id].tsx
@@ -5,9 +5,10 @@ import { ShoppingList, ShoppingItem } from '@/types';
 import { StorageService } from '@/services/storage';
 import { ParserService } from '@/services/parser';
 import ItemTile from '@/components/ItemTile';
-import { colors } from '@/constants/Colors';
+import { useTheme } from '@/context/ThemeContext';
 
 export default function ListDetailScreen() {
+  const { colors } = useTheme();
   const params = useLocalSearchParams();
   const idParam = Array.isArray(params.id) ? params.id[0] : params.id;
   const router = useRouter();
@@ -149,7 +150,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 8,
     marginBottom: 4,
-    backgroundColor: '#F9F9F9',
+    backgroundColor: colors.control,
   },
   title: {
     fontSize: 24,

--- a/project/app/(tabs)/settings.tsx
+++ b/project/app/(tabs)/settings.tsx
@@ -27,7 +27,6 @@ import { useTheme } from '@/context/ThemeContext';
 import { UserSubscription } from '@/types';
 import { StorageService } from '@/services/storage';
 import { router } from 'expo-router';
-import { colors } from '@/constants/Colors';
 
 export default function SettingsScreen() {
   const [subscription, setSubscription] = useState<UserSubscription | null>(null);

--- a/project/app/camera.tsx
+++ b/project/app/camera.tsx
@@ -9,12 +9,13 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { CameraView, CameraType, useCameraPermissions } from 'expo-camera';
 import { X, Camera, FlipHorizontal, Zap } from 'lucide-react-native';
-import { colors } from '@/constants/Colors';
+import { useTheme } from '@/context/ThemeContext';
 import { router, useLocalSearchParams } from 'expo-router';
 import { StorageService } from '@/services/storage';
 import { ParserService } from '@/services/parser';
 
 export default function CameraScreen() {
+  const { colors } = useTheme();
   const { itemId } = useLocalSearchParams();
   const [facing, setFacing] = useState<CameraType>('back');
   const [permission, requestPermission] = useCameraPermissions();

--- a/project/app/paywall.tsx
+++ b/project/app/paywall.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   Alert,
 } from 'react-native';
+import { useTheme } from '@/context/ThemeContext';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { X, Crown, Check, Zap, Camera, Users, Cloud } from 'lucide-react-native';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -64,6 +65,7 @@ const FEATURES = [
 ];
 
 export default function PaywallScreen() {
+  const { colors } = useTheme();
   const [selectedPlan, setSelectedPlan] = useState('annual');
   const [subscription, setSubscription] = useState<UserSubscription | null>(null);
   const [loading, setLoading] = useState(false);
@@ -242,7 +244,7 @@ export default function PaywallScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
   },
   header: {
     paddingTop: 20,
@@ -285,13 +287,13 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 20,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     marginBottom: 16,
   },
   feature: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     padding: 16,
     borderRadius: 12,
     marginBottom: 8,
@@ -305,7 +307,7 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: '#1C1C1E',
+    backgroundColor: colors.text,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 16,
@@ -316,19 +318,19 @@ const styles = StyleSheet.create({
   featureTitle: {
     fontSize: 16,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     marginBottom: 4,
   },
   featureDescription: {
     fontSize: 14,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
   },
   plansSection: {
     padding: 16,
   },
   planCard: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderRadius: 16,
     padding: 20,
     marginBottom: 12,
@@ -342,14 +344,14 @@ const styles = StyleSheet.create({
     elevation: 3,
   },
   planCardSelected: {
-    borderColor: '#007AFF',
-    backgroundColor: '#F0F8FF',
+    borderColor: colors.primary,
+    backgroundColor: colors.highlight,
   },
   popularBadge: {
     position: 'absolute',
     top: -8,
     left: 20,
-    backgroundColor: '#FF3B30',
+    backgroundColor: colors.danger,
     paddingHorizontal: 12,
     paddingVertical: 4,
     borderRadius: 12,
@@ -363,7 +365,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: -8,
     right: 20,
-    backgroundColor: '#FF9500',
+    backgroundColor: colors.warning,
     paddingHorizontal: 12,
     paddingVertical: 4,
     borderRadius: 12,
@@ -382,13 +384,13 @@ const styles = StyleSheet.create({
   planTitle: {
     fontSize: 18,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   planSavings: {
     fontSize: 12,
     fontFamily: 'Inter-SemiBold',
-    color: '#34C759',
-    backgroundColor: '#E8F5E8',
+    color: colors.success,
+    backgroundColor: colors.highlight,
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 8,
@@ -401,12 +403,12 @@ const styles = StyleSheet.create({
   planPrice: {
     fontSize: 24,
     fontFamily: 'Inter-Bold',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   planPeriod: {
     fontSize: 14,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
     marginLeft: 4,
   },
   planSelector: {
@@ -417,16 +419,16 @@ const styles = StyleSheet.create({
     height: 24,
     borderRadius: 12,
     borderWidth: 2,
-    borderColor: '#C7C7CC',
+    borderColor: colors.separator,
     justifyContent: 'center',
     alignItems: 'center',
   },
   planSelectorSelected: {
-    backgroundColor: '#007AFF',
-    borderColor: '#007AFF',
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
   },
   currentUsage: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     margin: 16,
     padding: 20,
     borderRadius: 16,
@@ -439,7 +441,7 @@ const styles = StyleSheet.create({
   usageTitle: {
     fontSize: 16,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     marginBottom: 16,
   },
   usageStats: {
@@ -452,29 +454,29 @@ const styles = StyleSheet.create({
   usageValue: {
     fontSize: 20,
     fontFamily: 'Inter-Bold',
-    color: '#FF3B30',
+    color: colors.danger,
   },
   usageLabel: {
     fontSize: 12,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
     marginTop: 4,
   },
   footer: {
     padding: 16,
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderTopWidth: 1,
-    borderTopColor: '#E5E5EA',
+    borderTopColor: colors.border,
   },
   purchaseButton: {
-    backgroundColor: '#007AFF',
+    backgroundColor: colors.primary,
     paddingVertical: 16,
     borderRadius: 24,
     alignItems: 'center',
     marginBottom: 12,
   },
   purchaseButtonDisabled: {
-    backgroundColor: '#C7C7CC',
+    backgroundColor: colors.separator,
   },
   purchaseButtonText: {
     fontSize: 18,
@@ -484,7 +486,7 @@ const styles = StyleSheet.create({
   footerText: {
     fontSize: 12,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
     textAlign: 'center',
   },
 });

--- a/project/components/ItemTile.tsx
+++ b/project/components/ItemTile.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, TextInput } from 'react-native';
-import { colors } from '@/constants/Colors';
+import { useTheme } from '@/context/ThemeContext';
 import { Check, Camera, Trash2 } from 'lucide-react-native';
 import Animated, { 
   useSharedValue, 
@@ -20,14 +20,15 @@ interface ItemTileProps {
   showActions?: boolean;
 }
 
-export default function ItemTile({ 
-  item, 
-  onToggle, 
-  onDelete, 
-  onScan, 
+export default function ItemTile({
+  item,
+  onToggle,
+  onDelete,
+  onScan,
   onQuantityChange,
-  showActions = true 
+  showActions = true
 }: ItemTileProps) {
+  const { colors } = useTheme();
   const scale = useSharedValue(1);
   const opacity = useSharedValue(item.checked ? 0.6 : 1);
 

--- a/project/components/VoiceButton.tsx
+++ b/project/components/VoiceButton.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { TouchableOpacity, Text, StyleSheet, View, ActivityIndicator } from 'react-native';
+import { useTheme } from '@/context/ThemeContext';
 import { Mic, MicOff } from 'lucide-react-native';
 import Animated, { 
   useSharedValue, 
@@ -19,6 +20,7 @@ interface VoiceButtonProps {
 }
 
 export default function VoiceButton({ onResult, onError, disabled }: VoiceButtonProps) {
+  const { colors } = useTheme();
   const [isListening, setIsListening] = useState(false);
   const scale = useSharedValue(1);
   const opacity = useSharedValue(1);
@@ -98,7 +100,7 @@ export default function VoiceButton({ onResult, onError, disabled }: VoiceButton
               <ActivityIndicator size="small" color="white" style={styles.spinner} />
             </View>
           ) : (
-            <Mic size={28} color={disabled ? '#C7C7CC' : 'white'} />
+            <Mic size={28} color={disabled ? colors.separator : 'white'} />
           )}
         </TouchableOpacity>
       </Animated.View>
@@ -119,21 +121,21 @@ const styles = StyleSheet.create({
     width: 80,
     height: 80,
     borderRadius: 40,
-    backgroundColor: '#007AFF',
+    backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
-    shadowColor: '#007AFF',
+    shadowColor: colors.primary,
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
     elevation: 8,
   },
   buttonListening: {
-    backgroundColor: '#FF3B30',
-    shadowColor: '#FF3B30',
+    backgroundColor: colors.danger,
+    shadowColor: colors.danger,
   },
   buttonDisabled: {
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
     shadowOpacity: 0,
     elevation: 0,
   },
@@ -150,10 +152,10 @@ const styles = StyleSheet.create({
     marginTop: 12,
     fontSize: 16,
     fontFamily: 'Inter-Medium',
-    color: '#1C1C1E',
+    color: colors.text,
     textAlign: 'center',
   },
   labelDisabled: {
-    color: '#C7C7CC',
+    color: colors.separator,
   },
 });

--- a/project/constants/Colors.ts
+++ b/project/constants/Colors.ts
@@ -1,35 +1,126 @@
 export const palettes = {
-  blue: {
-    primary: '#007AFF'
+  fresh: {
+    light: {
+      primary: '#007AFF',
+      success: '#34C759',
+      danger: '#FF3B30',
+      warning: '#FF9500',
+      background: '#F2F2F7',
+      surface: '#FFFFFF',
+      text: '#1C1C1E',
+      muted: '#8E8E93',
+      border: '#E5E5EA',
+      control: '#F2F2F7',
+      highlight: '#E3F2FD',
+      separator: '#C7C7CC'
+    },
+    dark: {
+      primary: '#0A84FF',
+      success: '#30D158',
+      danger: '#FF453A',
+      warning: '#FF9F0A',
+      background: '#1C1C1E',
+      surface: '#2C2C2E',
+      text: '#FFFFFF',
+      muted: '#8E8E93',
+      border: '#3A3A3C',
+      control: '#48484A',
+      highlight: '#0A84FF20',
+      separator: '#636366'
+    }
   },
-  green: {
-    primary: '#34C759'
+  tropical: {
+    light: {
+      primary: '#00B894',
+      success: '#26de81',
+      danger: '#ff6b6b',
+      warning: '#fdcb6e',
+      background: '#E0F2F1',
+      surface: '#FFFFFF',
+      text: '#004D40',
+      muted: '#4F4F4F',
+      border: '#B2DFDB',
+      control: '#C8E6C9',
+      highlight: '#B2EBF2',
+      separator: '#A7A7A7'
+    },
+    dark: {
+      primary: '#1dd1a1',
+      success: '#10ac84',
+      danger: '#ee5253',
+      warning: '#feca57',
+      background: '#004D40',
+      surface: '#005B4F',
+      text: '#FFFFFF',
+      muted: '#B0BEC5',
+      border: '#004D40',
+      control: '#00695C',
+      highlight: '#004D40',
+      separator: '#607D8B'
+    }
   },
-  orange: {
-    primary: '#FF9500'
+  berry: {
+    light: {
+      primary: '#AF52DE',
+      success: '#34C759',
+      danger: '#FF375F',
+      warning: '#FF9500',
+      background: '#F8EAF9',
+      surface: '#FFFFFF',
+      text: '#1D1331',
+      muted: '#6E6E73',
+      border: '#E5E5EA',
+      control: '#F3E5F5',
+      highlight: '#F2E1F9',
+      separator: '#C7C7CC'
+    },
+    dark: {
+      primary: '#BF5AF2',
+      success: '#30D158',
+      danger: '#FF375F',
+      warning: '#FF9F0A',
+      background: '#1D1331',
+      surface: '#2C1A43',
+      text: '#FFFFFF',
+      muted: '#A284B7',
+      border: '#3A3A3C',
+      control: '#3C2E56',
+      highlight: '#2C1A43',
+      separator: '#636366'
+    }
+  },
+  orchard: {
+    light: {
+      primary: '#5AC8FA',
+      success: '#34C759',
+      danger: '#FF3B30',
+      warning: '#FF9500',
+      background: '#EFFBFF',
+      surface: '#FFFFFF',
+      text: '#1C1C1E',
+      muted: '#8E8E93',
+      border: '#E5E5EA',
+      control: '#DFF6FD',
+      highlight: '#E0F7FF',
+      separator: '#C7C7CC'
+    },
+    dark: {
+      primary: '#64D2FF',
+      success: '#32D74B',
+      danger: '#FF453A',
+      warning: '#FF9F0A',
+      background: '#00141E',
+      surface: '#0A1F29',
+      text: '#FFFFFF',
+      muted: '#8E8E93',
+      border: '#3A3A3C',
+      control: '#123645',
+      highlight: '#0A1F29',
+      separator: '#636366'
+    }
   }
 } as const;
 
 export type PaletteName = keyof typeof palettes;
 
-export interface ThemeColors {
-  text: string;
-  background: string;
-  surface: string;
-  primary: string;
-}
-
-export const baseColors = {
-  light: {
-    text: '#1C1C1E',
-    background: '#F2F2F7',
-    surface: '#FFFFFF'
-  },
-  dark: {
-    text: '#FFFFFF',
-    background: '#1C1C1E',
-    surface: '#2C2C2E'
-  }
-} as const;
-
-export type ColorScheme = keyof typeof baseColors;
+export const colors = palettes.fresh.light;

--- a/project/context/ThemeContext.tsx
+++ b/project/context/ThemeContext.tsx
@@ -1,52 +1,75 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useState, useContext, useMemo, ReactNode } from 'react';
 import { useColorScheme } from 'react-native';
+import { palettes, PaletteName } from '../constants/Colors';
+import { setItem, getItem } from '../services/storage';
 
-export type ThemeColors = {
-  primary: string;
-  background: string;
-  surface: string;
-  text: string;
-};
-
-const lightColors: ThemeColors = {
-  primary: '#007AFF',
-  background: '#F2F2F7',
-  surface: '#FFFFFF',
-  text: '#1C1C1E',
-};
-
-const darkColors: ThemeColors = {
-  primary: '#0A84FF',
-  background: '#000000',
-  surface: '#1C1C1E',
-  text: '#FFFFFF',
-};
-
-interface ThemeContextValue {
-  colors: ThemeColors;
-  toggleTheme: () => void;
-  isDark: boolean;
+interface ThemeContextType {
+  colors: typeof palettes.fresh.light;
+  paletteName: PaletteName;
+  colorScheme: 'light' | 'dark';
+  setPalette: (name: PaletteName) => void;
+  toggleColorScheme: () => void;
 }
 
-const ThemeContext = createContext<ThemeContextValue>({
-  colors: lightColors,
-  toggleTheme: () => {},
-  isDark: false,
-});
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => {
   const systemScheme = useColorScheme();
-  const [isDark, setIsDark] = useState(systemScheme === 'dark');
+  const [colorScheme, setColorScheme] = useState<'light' | 'dark'>(systemScheme || 'light');
+  const [paletteName, setPaletteName] = useState<PaletteName>('fresh');
 
-  const toggleTheme = () => setIsDark((prev) => !prev);
+  React.useEffect(() => {
+    const loadTheme = async () => {
+      const savedPalette = await getItem<PaletteName>('theme_palette');
+      const savedScheme = await getItem<'light' | 'dark'>('theme_scheme');
+      if (savedPalette) {
+        setPaletteName(savedPalette);
+      }
+      if (savedScheme) {
+        setColorScheme(savedScheme);
+      } else {
+        setColorScheme(systemScheme || 'light');
+      }
+    };
+    loadTheme();
+  }, [systemScheme]);
 
-  const colors = isDark ? darkColors : lightColors;
+  const setPalette = async (name: PaletteName) => {
+    setPaletteName(name);
+    await setItem('theme_palette', name);
+  };
+
+  const toggleColorScheme = async () => {
+    const newScheme = colorScheme === 'light' ? 'dark' : 'light';
+    setColorScheme(newScheme);
+    await setItem('theme_scheme', newScheme);
+  };
+
+  const colors = palettes[paletteName][colorScheme];
+
+  const contextValue = useMemo(() => ({
+    colors,
+    paletteName,
+    setPalette,
+    colorScheme,
+    toggleColorScheme,
+  }), [colors, paletteName, colorScheme]);
 
   return (
-    <ThemeContext.Provider value={{ colors, toggleTheme, isDark }}>
+    <ThemeContext.Provider value={contextValue}>
       {children}
     </ThemeContext.Provider>
   );
 };
 
-export const useTheme = () => useContext(ThemeContext);
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/project/package.json
+++ b/project/package.json
@@ -53,6 +53,7 @@
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
     "@types/uuid": "^10.0.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "babel-plugin-module-resolver": "^5.0.0"
   }
 }

--- a/project/services/storage.ts
+++ b/project/services/storage.ts
@@ -157,3 +157,23 @@ export function useShoppingLists() {
 
   return { lists, loading, loadLists, deleteList, saveList };
 }
+
+export async function setItem<T>(key: string, value: T): Promise<void> {
+  try {
+    await AsyncStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error('Error setting item:', error);
+    throw error;
+  }
+}
+
+export async function getItem<T>(key: string): Promise<T | null> {
+  try {
+    const data = await AsyncStorage.getItem(key);
+    if (!data) return null;
+    return JSON.parse(data) as T;
+  } catch (error) {
+    console.error('Error getting item:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- restore color palettes with default export
- restore theme context with palette and scheme controls
- reintroduce `setItem`/`getItem` helpers in storage
- apply theme colors across remaining screens and components

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c657316c83309e1a88c8e0d90c06