### PR TITLE
Fix duplicate palettes import

### DIFF
--- a/project/app/(tabs)/calendar.tsx
+++ b/project/app/(tabs)/calendar.tsx
@@ -8,7 +8,8 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ChevronLeft, ChevronRight, Plus } from 'lucide-react-native';
-import { colors } from '@/constants/Colors';
+import { useTheme } from '@/context/ThemeContext';
+import { palettes } from '@/constants/Colors';
 import { ShoppingList } from '@/types';
 import { StorageService } from '@/services/storage';
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, addMonths, subMonths } from 'date-fns';
@@ -16,6 +17,8 @@ import { ptBR } from 'date-fns/locale';
 import { router } from 'expo-router';
 
 export default function CalendarScreen() {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
   const [currentDate, setCurrentDate] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [lists, setLists] = useState<ShoppingList[]>([]);
@@ -205,7 +208,7 @@ export default function CalendarScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (colors: typeof palettes.fresh.light) => StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.control,
@@ -251,7 +254,7 @@ const styles = StyleSheet.create({
     textTransform: 'capitalize',
   },
   calendar: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     marginHorizontal: 16,
     marginTop: 8,
     borderRadius: 12,
@@ -348,7 +351,7 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   listItem: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderRadius: 12,
     padding: 16,
     shadowColor: '#000',

--- a/project/app/(tabs)/create.tsx
+++ b/project/app/(tabs)/create.tsx
@@ -10,7 +10,8 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Calendar, Save, Trash2 } from 'lucide-react-native';
-import { colors } from '@/constants/Colors';
+import { useTheme } from '@/context/ThemeContext';
+import { palettes } from '@/constants/Colors';
 import { ShoppingList, ShoppingItem, ListCategory, UserSubscription } from '@/types';
 import { StorageService } from '@/services/storage';
 import { ParserService } from '@/services/parser';
@@ -22,6 +23,8 @@ import { router } from 'expo-router';
 const CATEGORIES: ListCategory[] = ['Mercado', 'Farmácia', 'Papelaria', 'Pet Shop'];
 
 export default function CreateScreen() {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
   const [title, setTitle] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<ListCategory>('Mercado');
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -134,23 +137,13 @@ export default function CreateScreen() {
       };
 
       await StorageService.saveList(newList);
-      
-      Alert.alert(
-        'Lista Salva!',
-        'Sua lista foi criada com sucesso.',
-        [
-          {
-            text: 'OK',
-            onPress: () => {
-              // Reset form
-              setTitle('');
-              setItems([]);
-              generateDefaultTitle();
-              router.push('/(tabs)');
-            },
-          },
-        ]
-      );
+
+      // Reset form before navigating
+      setTitle('');
+      setItems([]);
+      generateDefaultTitle();
+
+      router.push('/(tabs)');
     } catch (error) {
       console.error('Error saving list:', error);
       setError('Erro ao salvar lista');
@@ -293,7 +286,7 @@ export default function CreateScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (colors: typeof palettes.fresh.light) => StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.control,
@@ -366,7 +359,7 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
     borderRadius: 8,
     padding: 12,
-    backgroundColor: '#F9F9F9',
+    backgroundColor: colors.control,
   },
   categoryGrid: {
     flexDirection: 'row',
@@ -378,7 +371,7 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     borderWidth: 1,
     borderColor: colors.border,
-    backgroundColor: '#F9F9F9',
+    backgroundColor: colors.control,
   },
   categoryButtonSelected: {
     backgroundColor: colors.primary,
@@ -399,7 +392,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.border,
     borderRadius: 8,
-    backgroundColor: '#F9F9F9',
+    backgroundColor: colors.control,
   },
   dateButtonText: {
     fontSize: 16,

--- a/project/app/(tabs)/list/[id].tsx
+++ b/project/app/(tabs)/list/[id].tsx
@@ -5,14 +5,18 @@ import { ShoppingList, ShoppingItem } from '@/types';
 import { StorageService } from '@/services/storage';
 import { ParserService } from '@/services/parser';
 import ItemTile from '@/components/ItemTile';
-import { colors } from '@/constants/Colors';
+import { useTheme } from '@/context/ThemeContext';
+import { palettes } from '@/constants/Colors';
 
 export default function ListDetailScreen() {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
   const params = useLocalSearchParams();
   const idParam = Array.isArray(params.id) ? params.id[0] : params.id;
   const router = useRouter();
   const [list, setList] = useState<ShoppingList | null>(null);
   const [items, setItems] = useState<ShoppingItem[]>([]);
+  const [priceInputs, setPriceInputs] = useState<Record<string, string>>({});
   const [title, setTitle] = useState('');
   const [error, setError] = useState<string | null>(null);
 
@@ -28,6 +32,11 @@ export default function ListDetailScreen() {
         setList(found);
         setItems(found.items.map(item => ({ ...item, quantity: item.quantity ?? 1 })));
         setTitle(found.title);
+        const inputs: Record<string, string> = {};
+        found.items.forEach(i => {
+          inputs[i.id] = i.price !== undefined ? i.price.toString().replace('.', ',') : '';
+        });
+        setPriceInputs(inputs);
       }
     } catch (e) {
       setError('Erro ao carregar lista');
@@ -38,12 +47,17 @@ export default function ListDetailScreen() {
     setItems(prev => prev.map(item => item.id === itemId ? { ...item, quantity: newQuantity } : item));
   };
 
-  const handlePriceChange = (itemId: string, newPrice: string) => {
-    const parsed = parseFloat(newPrice.replace(',', '.'));
-    setItems(prev => prev.map(item => item.id === itemId ? {
-      ...item,
-      price: isNaN(parsed) ? undefined : parsed,
-    } : item));
+  const handlePriceChange = (itemId: string, text: string) => {
+    const sanitized = text.replace(/[^0-9.,]/g, '');
+    setPriceInputs(prev => ({ ...prev, [itemId]: sanitized }));
+    const parsed = parseFloat(sanitized.replace(',', '.'));
+    setItems(prev =>
+      prev.map(item =>
+        item.id === itemId
+          ? { ...item, price: Number.isNaN(parsed) ? undefined : parsed }
+          : item
+      )
+    );
   };
 
   const handleDeleteItem = (itemId: string) => {
@@ -106,9 +120,9 @@ export default function ListDetailScreen() {
               <Text style={styles.priceLabel}>Preço:</Text>
               <TextInput
                 style={styles.priceInput}
-                keyboardType="numeric"
+                keyboardType="decimal-pad"
                 inputMode="decimal"
-                value={item.price !== undefined ? item.price.toString().replace('.', ',') : ''}
+                value={priceInputs[item.id] ?? ''}
                 onChangeText={value => handlePriceChange(item.id, value)}
                 placeholder="0,00"
               />
@@ -125,7 +139,7 @@ export default function ListDetailScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (colors: typeof palettes.fresh.light) => StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.control,
@@ -149,7 +163,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 8,
     marginBottom: 4,
-    backgroundColor: '#F9F9F9',
+    backgroundColor: colors.control,
   },
   title: {
     fontSize: 24,

--- a/project/app/(tabs)/settings.tsx
+++ b/project/app/(tabs)/settings.tsx
@@ -22,18 +22,18 @@ import {
   Trash2
 } from 'lucide-react-native';
 import { Feather } from '@expo/vector-icons';
-import { palettes, PaletteName } from '@/constants/Colors';
+import { palettes as colorPalettes, PaletteName } from '@/constants/Colors';
 import { useTheme } from '@/context/ThemeContext';
 import { UserSubscription } from '@/types';
 import { StorageService } from '@/services/storage';
 import { router } from 'expo-router';
-import { colors } from '@/constants/Colors';
 
 export default function SettingsScreen() {
   const [subscription, setSubscription] = useState<UserSubscription | null>(null);
   const [notifications, setNotifications] = useState(true);
   const [voiceConfirmation, setVoiceConfirmation] = useState(false);
   const { colors, colorScheme, toggleColorScheme, paletteName, setPalette } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
 
   useEffect(() => {
     loadSubscription();
@@ -179,7 +179,7 @@ export default function SettingsScreen() {
         <View style={styles.section}>
           <Text style={[styles.sectionTitle, { color: colors.text }]}>Paleta de Cores</Text>
           <View style={[styles.settingItem, { backgroundColor: colors.surface, flexDirection: 'column', alignItems: 'stretch' }]}>
-            {Object.keys(palettes).map((name) => (
+          {Object.keys(colorPalettes).map((name) => (
               <Pressable key={name} onPress={() => setPalette(name as PaletteName)} style={styles.paletteOption}>
                 <Text style={[styles.settingTitle, { color: colors.text, textTransform: 'capitalize' }]}>{name}</Text>
                 {paletteName === name && (
@@ -276,7 +276,7 @@ export default function SettingsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (colors: typeof colorPalettes.fresh.light) => StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.control,

--- a/project/app/camera.tsx
+++ b/project/app/camera.tsx
@@ -9,12 +9,15 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { CameraView, CameraType, useCameraPermissions } from 'expo-camera';
 import { X, Camera, FlipHorizontal, Zap } from 'lucide-react-native';
-import { colors } from '@/constants/Colors';
+import { useTheme } from '@/context/ThemeContext';
+import { palettes } from '@/constants/Colors';
 import { router, useLocalSearchParams } from 'expo-router';
 import { StorageService } from '@/services/storage';
 import { ParserService } from '@/services/parser';
 
 export default function CameraScreen() {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
   const { itemId } = useLocalSearchParams();
   const [facing, setFacing] = useState<CameraType>('back');
   const [permission, requestPermission] = useCameraPermissions();
@@ -210,7 +213,7 @@ export default function CameraScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (colors: typeof palettes.fresh.light) => StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: 'black',

--- a/project/app/paywall.tsx
+++ b/project/app/paywall.tsx
@@ -7,6 +7,8 @@ import {
   TouchableOpacity,
   Alert,
 } from 'react-native';
+import { useTheme } from '@/context/ThemeContext';
+import { palettes } from '@/constants/Colors';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { X, Crown, Check, Zap, Camera, Users, Cloud } from 'lucide-react-native';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -64,6 +66,8 @@ const FEATURES = [
 ];
 
 export default function PaywallScreen() {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
   const [selectedPlan, setSelectedPlan] = useState('annual');
   const [subscription, setSubscription] = useState<UserSubscription | null>(null);
   const [loading, setLoading] = useState(false);
@@ -239,10 +243,10 @@ export default function PaywallScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (colors: typeof palettes.fresh.light) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
   },
   header: {
     paddingTop: 20,
@@ -285,13 +289,13 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 20,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     marginBottom: 16,
   },
   feature: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     padding: 16,
     borderRadius: 12,
     marginBottom: 8,
@@ -305,7 +309,7 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: '#1C1C1E',
+    backgroundColor: colors.text,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 16,
@@ -316,19 +320,19 @@ const styles = StyleSheet.create({
   featureTitle: {
     fontSize: 16,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     marginBottom: 4,
   },
   featureDescription: {
     fontSize: 14,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
   },
   plansSection: {
     padding: 16,
   },
   planCard: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderRadius: 16,
     padding: 20,
     marginBottom: 12,
@@ -342,14 +346,14 @@ const styles = StyleSheet.create({
     elevation: 3,
   },
   planCardSelected: {
-    borderColor: '#007AFF',
-    backgroundColor: '#F0F8FF',
+    borderColor: colors.primary,
+    backgroundColor: colors.highlight,
   },
   popularBadge: {
     position: 'absolute',
     top: -8,
     left: 20,
-    backgroundColor: '#FF3B30',
+    backgroundColor: colors.danger,
     paddingHorizontal: 12,
     paddingVertical: 4,
     borderRadius: 12,
@@ -363,7 +367,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: -8,
     right: 20,
-    backgroundColor: '#FF9500',
+    backgroundColor: colors.warning,
     paddingHorizontal: 12,
     paddingVertical: 4,
     borderRadius: 12,
@@ -382,13 +386,13 @@ const styles = StyleSheet.create({
   planTitle: {
     fontSize: 18,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   planSavings: {
     fontSize: 12,
     fontFamily: 'Inter-SemiBold',
-    color: '#34C759',
-    backgroundColor: '#E8F5E8',
+    color: colors.success,
+    backgroundColor: colors.highlight,
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 8,
@@ -401,12 +405,12 @@ const styles = StyleSheet.create({
   planPrice: {
     fontSize: 24,
     fontFamily: 'Inter-Bold',
-    color: '#1C1C1E',
+    color: colors.text,
   },
   planPeriod: {
     fontSize: 14,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
     marginLeft: 4,
   },
   planSelector: {
@@ -417,16 +421,16 @@ const styles = StyleSheet.create({
     height: 24,
     borderRadius: 12,
     borderWidth: 2,
-    borderColor: '#C7C7CC',
+    borderColor: colors.separator,
     justifyContent: 'center',
     alignItems: 'center',
   },
   planSelectorSelected: {
-    backgroundColor: '#007AFF',
-    borderColor: '#007AFF',
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
   },
   currentUsage: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     margin: 16,
     padding: 20,
     borderRadius: 16,
@@ -439,7 +443,7 @@ const styles = StyleSheet.create({
   usageTitle: {
     fontSize: 16,
     fontFamily: 'Inter-SemiBold',
-    color: '#1C1C1E',
+    color: colors.text,
     marginBottom: 16,
   },
   usageStats: {
@@ -452,29 +456,29 @@ const styles = StyleSheet.create({
   usageValue: {
     fontSize: 20,
     fontFamily: 'Inter-Bold',
-    color: '#FF3B30',
+    color: colors.danger,
   },
   usageLabel: {
     fontSize: 12,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
     marginTop: 4,
   },
   footer: {
     padding: 16,
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     borderTopWidth: 1,
-    borderTopColor: '#E5E5EA',
+    borderTopColor: colors.border,
   },
   purchaseButton: {
-    backgroundColor: '#007AFF',
+    backgroundColor: colors.primary,
     paddingVertical: 16,
     borderRadius: 24,
     alignItems: 'center',
     marginBottom: 12,
   },
   purchaseButtonDisabled: {
-    backgroundColor: '#C7C7CC',
+    backgroundColor: colors.separator,
   },
   purchaseButtonText: {
     fontSize: 18,
@@ -484,7 +488,7 @@ const styles = StyleSheet.create({
   footerText: {
     fontSize: 12,
     fontFamily: 'Inter-Regular',
-    color: '#8E8E93',
+    color: colors.muted,
     textAlign: 'center',
   },
 });

--- a/project/components/ItemTile.tsx
+++ b/project/components/ItemTile.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, TextInput } from 'react-native';
-import { colors } from '@/constants/Colors';
+import { useTheme } from '@/context/ThemeContext';
+import { palettes } from '@/constants/Colors';
 import { Check, Camera, Trash2 } from 'lucide-react-native';
 import Animated, { 
   useSharedValue, 
@@ -20,14 +21,16 @@ interface ItemTileProps {
   showActions?: boolean;
 }
 
-export default function ItemTile({ 
-  item, 
-  onToggle, 
-  onDelete, 
-  onScan, 
+export default function ItemTile({
+  item,
+  onToggle,
+  onDelete,
+  onScan,
   onQuantityChange,
-  showActions = true 
+  showActions = true
 }: ItemTileProps) {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
   const scale = useSharedValue(1);
   const opacity = useSharedValue(item.checked ? 0.6 : 1);
 
@@ -130,7 +133,7 @@ export default function ItemTile({
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (colors: typeof palettes.fresh.light) => StyleSheet.create({
   container: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/project/components/VoiceButton.tsx
+++ b/project/components/VoiceButton.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { TouchableOpacity, Text, StyleSheet, View, ActivityIndicator } from 'react-native';
+import { useTheme } from '@/context/ThemeContext';
+import { palettes } from '@/constants/Colors';
 import { Mic, MicOff } from 'lucide-react-native';
 import Animated, { 
   useSharedValue, 
@@ -19,6 +21,8 @@ interface VoiceButtonProps {
 }
 
 export default function VoiceButton({ onResult, onError, disabled }: VoiceButtonProps) {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
   const [isListening, setIsListening] = useState(false);
   const scale = useSharedValue(1);
   const opacity = useSharedValue(1);
@@ -98,7 +102,7 @@ export default function VoiceButton({ onResult, onError, disabled }: VoiceButton
               <ActivityIndicator size="small" color="white" style={styles.spinner} />
             </View>
           ) : (
-            <Mic size={28} color={disabled ? '#C7C7CC' : 'white'} />
+            <Mic size={28} color={disabled ? colors.separator : 'white'} />
           )}
         </TouchableOpacity>
       </Animated.View>
@@ -110,7 +114,7 @@ export default function VoiceButton({ onResult, onError, disabled }: VoiceButton
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (colors: typeof palettes.fresh.light) => StyleSheet.create({
   container: {
     alignItems: 'center',
     marginVertical: 20,
@@ -119,21 +123,21 @@ const styles = StyleSheet.create({
     width: 80,
     height: 80,
     borderRadius: 40,
-    backgroundColor: '#007AFF',
+    backgroundColor: colors.primary,
     justifyContent: 'center',
     alignItems: 'center',
-    shadowColor: '#007AFF',
+    shadowColor: colors.primary,
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
     elevation: 8,
   },
   buttonListening: {
-    backgroundColor: '#FF3B30',
-    shadowColor: '#FF3B30',
+    backgroundColor: colors.danger,
+    shadowColor: colors.danger,
   },
   buttonDisabled: {
-    backgroundColor: '#F2F2F7',
+    backgroundColor: colors.control,
     shadowOpacity: 0,
     elevation: 0,
   },
@@ -150,10 +154,10 @@ const styles = StyleSheet.create({
     marginTop: 12,
     fontSize: 16,
     fontFamily: 'Inter-Medium',
-    color: '#1C1C1E',
+    color: colors.text,
     textAlign: 'center',
   },
   labelDisabled: {
-    color: '#C7C7CC',
+    color: colors.separator,
   },
 });

--- a/project/constants/Colors.ts
+++ b/project/constants/Colors.ts
@@ -1,35 +1,126 @@
 export const palettes = {
-  blue: {
-    primary: '#007AFF'
+  fresh: {
+    light: {
+      primary: '#007AFF',
+      success: '#34C759',
+      danger: '#FF3B30',
+      warning: '#FF9500',
+      background: '#F2F2F7',
+      surface: '#FFFFFF',
+      text: '#1C1C1E',
+      muted: '#8E8E93',
+      border: '#E5E5EA',
+      control: '#F2F2F7',
+      highlight: '#E3F2FD',
+      separator: '#C7C7CC'
+    },
+    dark: {
+      primary: '#0A84FF',
+      success: '#30D158',
+      danger: '#FF453A',
+      warning: '#FF9F0A',
+      background: '#1C1C1E',
+      surface: '#2C2C2E',
+      text: '#FFFFFF',
+      muted: '#8E8E93',
+      border: '#3A3A3C',
+      control: '#48484A',
+      highlight: '#0A84FF20',
+      separator: '#636366'
+    }
   },
-  green: {
-    primary: '#34C759'
+  tropical: {
+    light: {
+      primary: '#00B894',
+      success: '#26de81',
+      danger: '#ff6b6b',
+      warning: '#fdcb6e',
+      background: '#E0F2F1',
+      surface: '#FFFFFF',
+      text: '#004D40',
+      muted: '#4F4F4F',
+      border: '#B2DFDB',
+      control: '#C8E6C9',
+      highlight: '#B2EBF2',
+      separator: '#A7A7A7'
+    },
+    dark: {
+      primary: '#1dd1a1',
+      success: '#10ac84',
+      danger: '#ee5253',
+      warning: '#feca57',
+      background: '#004D40',
+      surface: '#005B4F',
+      text: '#FFFFFF',
+      muted: '#B0BEC5',
+      border: '#004D40',
+      control: '#00695C',
+      highlight: '#004D40',
+      separator: '#607D8B'
+    }
   },
-  orange: {
-    primary: '#FF9500'
+  berry: {
+    light: {
+      primary: '#AF52DE',
+      success: '#34C759',
+      danger: '#FF375F',
+      warning: '#FF9500',
+      background: '#F8EAF9',
+      surface: '#FFFFFF',
+      text: '#1D1331',
+      muted: '#6E6E73',
+      border: '#E5E5EA',
+      control: '#F3E5F5',
+      highlight: '#F2E1F9',
+      separator: '#C7C7CC'
+    },
+    dark: {
+      primary: '#BF5AF2',
+      success: '#30D158',
+      danger: '#FF375F',
+      warning: '#FF9F0A',
+      background: '#1D1331',
+      surface: '#2C1A43',
+      text: '#FFFFFF',
+      muted: '#A284B7',
+      border: '#3A3A3C',
+      control: '#3C2E56',
+      highlight: '#2C1A43',
+      separator: '#636366'
+    }
+  },
+  orchard: {
+    light: {
+      primary: '#5AC8FA',
+      success: '#34C759',
+      danger: '#FF3B30',
+      warning: '#FF9500',
+      background: '#EFFBFF',
+      surface: '#FFFFFF',
+      text: '#1C1C1E',
+      muted: '#8E8E93',
+      border: '#E5E5EA',
+      control: '#DFF6FD',
+      highlight: '#E0F7FF',
+      separator: '#C7C7CC'
+    },
+    dark: {
+      primary: '#64D2FF',
+      success: '#32D74B',
+      danger: '#FF453A',
+      warning: '#FF9F0A',
+      background: '#00141E',
+      surface: '#0A1F29',
+      text: '#FFFFFF',
+      muted: '#8E8E93',
+      border: '#3A3A3C',
+      control: '#123645',
+      highlight: '#0A1F29',
+      separator: '#636366'
+    }
   }
 } as const;
 
 export type PaletteName = keyof typeof palettes;
 
-export interface ThemeColors {
-  text: string;
-  background: string;
-  surface: string;
-  primary: string;
-}
-
-export const baseColors = {
-  light: {
-    text: '#1C1C1E',
-    background: '#F2F2F7',
-    surface: '#FFFFFF'
-  },
-  dark: {
-    text: '#FFFFFF',
-    background: '#1C1C1E',
-    surface: '#2C2C2E'
-  }
-} as const;
-
-export type ColorScheme = keyof typeof baseColors;
+export const colors = palettes.fresh.light;

--- a/project/context/ThemeContext.tsx
+++ b/project/context/ThemeContext.tsx
@@ -1,52 +1,75 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useState, useContext, useMemo, ReactNode } from 'react';
 import { useColorScheme } from 'react-native';
+import { palettes, PaletteName } from '../constants/Colors';
+import { setItem, getItem } from '../services/storage';
 
-export type ThemeColors = {
-  primary: string;
-  background: string;
-  surface: string;
-  text: string;
-};
-
-const lightColors: ThemeColors = {
-  primary: '#007AFF',
-  background: '#F2F2F7',
-  surface: '#FFFFFF',
-  text: '#1C1C1E',
-};
-
-const darkColors: ThemeColors = {
-  primary: '#0A84FF',
-  background: '#000000',
-  surface: '#1C1C1E',
-  text: '#FFFFFF',
-};
-
-interface ThemeContextValue {
-  colors: ThemeColors;
-  toggleTheme: () => void;
-  isDark: boolean;
+interface ThemeContextType {
+  colors: typeof palettes.fresh.light;
+  paletteName: PaletteName;
+  colorScheme: 'light' | 'dark';
+  setPalette: (name: PaletteName) => void;
+  toggleColorScheme: () => void;
 }
 
-const ThemeContext = createContext<ThemeContextValue>({
-  colors: lightColors,
-  toggleTheme: () => {},
-  isDark: false,
-});
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => {
   const systemScheme = useColorScheme();
-  const [isDark, setIsDark] = useState(systemScheme === 'dark');
+  const [colorScheme, setColorScheme] = useState<'light' | 'dark'>(systemScheme || 'light');
+  const [paletteName, setPaletteName] = useState<PaletteName>('fresh');
 
-  const toggleTheme = () => setIsDark((prev) => !prev);
+  React.useEffect(() => {
+    const loadTheme = async () => {
+      const savedPalette = await getItem<PaletteName>('theme_palette');
+      const savedScheme = await getItem<'light' | 'dark'>('theme_scheme');
+      if (savedPalette) {
+        setPaletteName(savedPalette);
+      }
+      if (savedScheme) {
+        setColorScheme(savedScheme);
+      } else {
+        setColorScheme(systemScheme || 'light');
+      }
+    };
+    loadTheme();
+  }, [systemScheme]);
 
-  const colors = isDark ? darkColors : lightColors;
+  const setPalette = async (name: PaletteName) => {
+    setPaletteName(name);
+    await setItem('theme_palette', name);
+  };
+
+  const toggleColorScheme = async () => {
+    const newScheme = colorScheme === 'light' ? 'dark' : 'light';
+    setColorScheme(newScheme);
+    await setItem('theme_scheme', newScheme);
+  };
+
+  const colors = palettes[paletteName][colorScheme];
+
+  const contextValue = useMemo(() => ({
+    colors,
+    paletteName,
+    setPalette,
+    colorScheme,
+    toggleColorScheme,
+  }), [colors, paletteName, colorScheme]);
 
   return (
-    <ThemeContext.Provider value={{ colors, toggleTheme, isDark }}>
+    <ThemeContext.Provider value={contextValue}>
       {children}
     </ThemeContext.Provider>
   );
 };
 
-export const useTheme = () => useContext(ThemeContext);
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/project/package.json
+++ b/project/package.json
@@ -53,6 +53,7 @@
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
     "@types/uuid": "^10.0.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "babel-plugin-module-resolver": "^5.0.0"
   }
 }

--- a/project/services/storage.ts
+++ b/project/services/storage.ts
@@ -36,7 +36,7 @@ export class StorageService {
   static async saveList(list: ShoppingList): Promise<void> {
     try {
       const lists = await this.getLists();
-      const existingIndex = lists.findIndex(l => l.id === list.id);
+      const existingIndex = lists.findIndex((l: ShoppingList) => l.id === list.id);
       
       if (existingIndex >= 0) {
         lists[existingIndex] = { ...list, updatedAt: new Date() };
@@ -54,7 +54,7 @@ export class StorageService {
   static async deleteList(listId: string): Promise<void> {
     try {
       const lists = await this.getLists();
-      const filteredLists = lists.filter(l => l.id !== listId);
+      const filteredLists = lists.filter((l: ShoppingList) => l.id !== listId);
       await AsyncStorage.setItem(STORAGE_KEYS.LISTS, JSON.stringify(filteredLists));
     } catch (error) {
       console.error('Error deleting list:', error);
@@ -156,4 +156,24 @@ export function useShoppingLists() {
   }, [loadLists]);
 
   return { lists, loading, loadLists, deleteList, saveList };
+}
+
+export async function setItem<T>(key: string, value: T): Promise<void> {
+  try {
+    await AsyncStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error('Error setting item:', error);
+    throw error;
+  }
+}
+
+export async function getItem<T>(key: string): Promise<T | null> {
+  try {
+    const data = await AsyncStorage.getItem(key);
+    if (!data) return null;
+    return JSON.parse(data) as T;
+  } catch (error) {
+    console.error('Error getting item:', error);
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary
- rename `palettes` import in settings screen to avoid duplicate
- accept comma for price inputs in list editor
- navigate back to lists after saving a new list

## Testing
- `npx tsc --noEmit` *(fails: missing modules)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c657316c83309e1a88c8e0d90c06