### PR TITLE
Fix duplicate useTheme import

### DIFF
--- a/project/app/(tabs)/settings.tsx
+++ b/project/app/(tabs)/settings.tsx
@@ -22,9 +22,9 @@ import {
   Trash2
 } from 'lucide-react-native';
 import { Feather } from '@expo/vector-icons';
-import { useThemeSpec, useTheme } from '@/theme/useTheme';
 import { palettes, PaletteName } from '@/constants/Colors';
-import { useTheme } from '@/context/ThemeContext';
+import { useTheme as useAppTheme } from '@/context/ThemeContext';
+import { useTheme as useGlassTheme } from '@/theme/useTheme';
 import { UserSubscription } from '@/types';
 import { StorageService } from '@/services/storage';
 import { router } from 'expo-router';
@@ -33,8 +33,8 @@ export default function SettingsScreen() {
   const [subscription, setSubscription] = useState<UserSubscription | null>(null);
   const [notifications, setNotifications] = useState(true);
   const [voiceConfirmation, setVoiceConfirmation] = useState(false);
-  const spec = useThemeSpec();
-  const { name: themeName, setName: setTheme, colors, colorScheme, toggleColorScheme, paletteName, setPalette } = useTheme();
+  const { name: themeName, setName: setTheme } = useGlassTheme();
+  const { colors, colorScheme, toggleColorScheme, paletteName, setPalette } = useAppTheme();
   const styles = React.useMemo(() => createStyles(colors), [colors]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fix duplicate useTheme import in settings screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ff0a80348330b28def9ae2d13544